### PR TITLE
ページネーションの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,3 +50,4 @@ gem "erb2haml"
 gem 'bootstrap-sass'
 gem 'devise', '4.1.0'
 gem 'carrierwave'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -206,6 +209,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
+  kaminari
   mysql2 (>= 0.3.13, < 0.5)
   pry-rails
   rails (= 4.2.6)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -2,7 +2,7 @@ class PrototypesController < ApplicationController
   before_action :set_prototype, only: [:show, :destroy, :edit, :update]
 
   def index
-    @prototypes = Prototype.includes(:user).all
+    @prototypes = Prototype.includes(:user).all.order("created_at DESC").page(params[:page]).per(8)
   end
 
   def show

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, { remote: remote, class: 'page-link' }

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.haml
+++ b/app/views/kaminari/_page.html.haml
@@ -1,0 +1,6 @@
+- if page.current?
+  %li.page-item.active
+    = content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+- else
+  %li.page-item
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/app/views/kaminari/_paginator.html.haml
+++ b/app/views/kaminari/_paginator.html.haml
@@ -1,0 +1,10 @@
+= paginator.render do
+  %nav
+    %ul.pagination
+      = first_page_tag unless current_page.first?
+      = prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          = page_tag page
+      = next_page_tag unless current_page.last?
+      = last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,0 +1,2 @@
+%li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -15,23 +15,11 @@
 .container.proto-list
   .row
     = render partial: "prototypes/prototype", collection: @prototypes
-.text-center
-  %ul.pagination
-    %li.disabled
-      %a{"aria-label" => "Previous", href: "#"}
-        %span{"aria-hidden" => "true"} «
-    %li.active
-      %a{href: "#"}
-        1
-        %span.sr-only (current)
-    %li
-      %a{href: "#"} 2
-    %li
-      %a{href: "#"} 3
-    %li
-      %a{href: "#"} 4
-    %li
-      %a{href: "#"} 5
-    %li
-      %a{"aria-label": "Next", href: "#"}
-        %span{"aria-hidden": "true"} »
+  .text-center
+    %ul.pagination
+      %li.disabled
+        %a{"aria-label" => "Previous", href: "#"}
+          %span{"aria-hidden" => "true"} «
+      %li.active
+        %a{href: "#"}
+          = paginate(@prototypes)

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -15,11 +15,8 @@
 .container.proto-list
   .row
     = render partial: "prototypes/prototype", collection: @prototypes
-  .text-center
-    %ul.pagination
-      %li.disabled
-        %a{"aria-label" => "Previous", href: "#"}
-          %span{"aria-hidden" => "true"} «
+.text-center
+  %ul.pagination
+    %nav.pagination
       %li.active
-        %a{href: "#"}
-          = paginate(@prototypes)
+        = paginate(@prototypes)


### PR DESCRIPTION
#WHAT
ページネーションの実装
#WHY
複数投稿された場合、個数を指定しページを作り見やすくするため。